### PR TITLE
feat: LFG auto-peer injection

### DIFF
--- a/dashboard/app/api/lfg/config/route.ts
+++ b/dashboard/app/api/lfg/config/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { getLFGConfig } from '@/lib/lfg';
+
+/**
+ * GET /api/lfg/config
+ * Returns LFG configuration (safe to expose - no secrets)
+ */
+export async function GET() {
+  const config = getLFGConfig();
+  return NextResponse.json(config);
+}

--- a/dashboard/app/api/metrics/route.ts
+++ b/dashboard/app/api/metrics/route.ts
@@ -5,6 +5,7 @@ import { addSnapshot, getRawHistory } from '@/lib/metrics-history';
 import { detectIssues } from '@/lib/issue-detector';
 import { reportIssues } from '@/lib/issue-reporter';
 import { updateActiveIssues } from '@/app/api/issues/route';
+import { lfgCheck } from '@/lib/lfg';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -385,7 +386,24 @@ export async function GET() {
     // Push to SkyNet (fire and forget — don't await, don't block response)
     pushToSkyNet(responseWithIssues).catch(() => {});
 
-    return NextResponse.json(responseWithIssues);
+    // === LFG (Live Fleet Gateway) Auto-Peer Injection ===
+    // Check if peer count is below threshold and fetch healthy peers from SkyNet
+    let lfgResult = null;
+    if (rpcConnected && peers < 10) {
+      try {
+        lfgResult = await lfgCheck(getRpcUrl(), peers);
+      } catch (e) {
+        // LFG is best-effort, don't fail the whole request
+        console.error('[LFG] Error during peer injection:', e);
+      }
+    }
+
+    // Add LFG result to response if triggered
+    const finalResponse = lfgResult?.triggered 
+      ? { ...responseWithIssues, lfg: lfgResult }
+      : responseWithIssues;
+
+    return NextResponse.json(finalResponse);
   } catch (error) {
     // Even on total failure, return diagnostics
     const diagnostics = await getNodeDiagnostics();

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -12,6 +12,7 @@ import ServerStats from '@/components/ServerStats';
 import StoragePanel from '@/components/StoragePanel';
 import PeerMap from '@/components/PeerMap';
 import SkyNetStatus from '@/components/SkyNetStatus';
+import { LFGBadge } from '@/components/LFGBadge';
 import type { MetricsData, PeersData } from '@/lib/types';
 
 interface MetricsHistory {
@@ -301,6 +302,9 @@ export default function Home() {
     <DashboardLayout>
       {/* Issue Banner - Shows active detected issues */}
       <IssueBanner />
+      
+      {/* LFG Badge - Shows when Live Fleet Gateway is active */}
+      <LFGBadge />
       
       <div className="space-y-6">
         {/* Error Banner with Diagnostics - Show when node is unhealthy */}

--- a/dashboard/components/LFGBadge.tsx
+++ b/dashboard/components/LFGBadge.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Zap, X, Users, Settings } from 'lucide-react';
+
+interface LFGResult {
+  triggered: boolean;
+  added: number;
+  failed: number;
+  enodesFetched?: number;
+}
+
+interface LFGConfig {
+  minPeers: number;
+  skyNetUrl: string;
+}
+
+export function LFGBadge() {
+  const [lfgResult, setLfgResult] = useState<LFGResult | null>(null);
+  const [lfgConfig, setLfgConfig] = useState<LFGConfig | null>(null);
+  const [showDetails, setShowDetails] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    // Fetch LFG config on mount
+    fetch('/api/lfg/config', { cache: 'no-store' })
+      .then(res => res.ok ? res.json() : null)
+      .then(data => {
+        if (data) setLfgConfig(data);
+      })
+      .catch(() => {});
+
+    // Check for LFG results in metrics endpoint
+    const checkLFG = async () => {
+      try {
+        const res = await fetch('/api/metrics', { cache: 'no-store' });
+        if (res.ok) {
+          const data = await res.json();
+          if (data.lfg?.triggered) {
+            setLfgResult(data.lfg);
+            setDismissed(false);
+          }
+        }
+      } catch {}
+    };
+
+    // Check immediately and then every 30 seconds
+    checkLFG();
+    const interval = setInterval(checkLFG, 30000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Auto-dismiss after 60 seconds
+  useEffect(() => {
+    if (lfgResult?.triggered) {
+      const timeout = setTimeout(() => {
+        setDismissed(true);
+      }, 60000);
+      return () => clearTimeout(timeout);
+    }
+  }, [lfgResult]);
+
+  if (!lfgResult?.triggered || dismissed) return null;
+
+  return (
+    <div className="animate-fade-in">
+      <div className="relative overflow-hidden rounded-xl border border-[#10B981]/30 bg-gradient-to-r from-[#10B981]/10 to-[#1E90FF]/10 p-4">
+        {/* Animated background effect */}
+        <div className="absolute inset-0 bg-gradient-to-r from-[#10B981]/5 via-[#1E90FF]/5 to-[#10B981]/5 animate-pulse" />
+        
+        <div className="relative flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-[#10B981]/20 border border-[#10B981]/30">
+              <Zap className="w-5 h-5 text-[#10B981]" />
+            </div>
+            
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="font-semibold text-[#F9FAFB]">LFG Active</span>
+                <span className="px-2 py-0.5 rounded-full bg-[#10B981]/20 text-[#10B981] text-xs font-medium">
+                  +{lfgResult.added} peers
+                </span>
+              </div>
+              <p className="text-sm text-[#9CA3AF]">
+                Live Fleet Gateway auto-added peers from SkyNet
+              </p>
+            </div>
+          </div>
+          
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setShowDetails(!showDetails)}
+              className="p-2 rounded-lg hover:bg-white/5 transition-colors text-[#6B7280] hover:text-[#F9FAFB]"
+              title="Toggle details"
+            >
+              <Settings className="w-4 h-4" />
+            </button>
+            <button
+              onClick={() => setDismissed(true)}
+              className="p-2 rounded-lg hover:bg-white/5 transition-colors text-[#6B7280] hover:text-[#F9FAFB]"
+              title="Dismiss"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+        
+        {/* Expanded details */}
+        {showDetails && (
+          <div className="relative mt-4 pt-4 border-t border-white/10 animate-fade-in">
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <div className="bg-white/5 rounded-lg p-3">
+                <div className="text-xs text-[#6B7280] mb-1">Peers Added</div>
+                <div className="text-lg font-semibold text-[#10B981]">{lfgResult.added}</div>
+              </div>
+              
+              <div className="bg-white/5 rounded-lg p-3">
+                <div className="text-xs text-[#6B7280] mb-1">Failed</div>
+                <div className={`text-lg font-semibold ${lfgResult.failed > 0 ? 'text-[#EF4444]' : 'text-[#10B981]'}`}>
+                  {lfgResult.failed}
+                </div>
+              </div>
+              
+              <div className="bg-white/5 rounded-lg p-3">
+                <div className="text-xs text-[#6B7280] mb-1">Available from SkyNet</div>
+                <div className="text-lg font-semibold text-[#1E90FF]">{lfgResult.enodesFetched || '—'}</div>
+              </div>
+              
+              <div className="bg-white/5 rounded-lg p-3">
+                <div className="text-xs text-[#6B7280] mb-1">Min Peers Threshold</div>
+                <div className="text-lg font-semibold text-[#F9FAFB]">{lfgConfig?.minPeers || '5'}</div>
+              </div>
+            </div>
+            
+            <div className="mt-3 text-xs text-[#6B7280]">
+              <span className="inline-flex items-center gap-1">
+                <Users className="w-3 h-3" />
+                SkyNet Source: {lfgConfig?.skyNetUrl || 'https://net.xdc.network/api/v1'}
+              </span>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/lib/lfg.ts
+++ b/dashboard/lib/lfg.ts
@@ -1,0 +1,125 @@
+/**
+ * LFG (Live Fleet Gateway) - Auto-peer injection
+ * 
+ * Automatically fetches healthy peers from SkyNet when local peer count
+ * drops below the MIN_PEERS threshold.
+ */
+
+const SKYNET_URL = process.env.SKYNET_API_URL || 'https://net.xdc.network/api/v1';
+const MIN_PEERS = parseInt(process.env.MIN_PEERS || '5');
+
+interface LFGResult {
+  triggered: boolean;
+  added: number;
+  failed: number;
+  enodesFetched?: number;
+}
+
+/**
+ * Fetch healthy peers from SkyNet's LFG endpoint
+ */
+export async function fetchHealthyPeers(): Promise<string[]> {
+  try {
+    const res = await fetch(`${SKYNET_URL}/peers/healthy?format=json`, {
+      signal: AbortSignal.timeout(10000),
+    });
+    
+    if (!res.ok) {
+      console.error(`[LFG] SkyNet returned ${res.status}`);
+      return [];
+    }
+    
+    const data = await res.json();
+    return data.enodes || [];
+  } catch (error) {
+    console.error('[LFG] Failed to fetch healthy peers:', error);
+    return [];
+  }
+}
+
+/**
+ * Add peers to local XDC node via admin_addPeer RPC
+ */
+export async function addPeers(rpcUrl: string, enodes: string[]): Promise<{ added: number; failed: number }> {
+  let added = 0;
+  let failed = 0;
+  
+  for (const enode of enodes) {
+    try {
+      const res = await fetch(rpcUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ 
+          jsonrpc: '2.0', 
+          method: 'admin_addPeer', 
+          params: [enode], 
+          id: 1 
+        }),
+        signal: AbortSignal.timeout(5000),
+      });
+      
+      const data = await res.json();
+      if (data.result === true) {
+        added++;
+      } else {
+        failed++;
+        console.log(`[LFG] addPeer returned false for ${enode.slice(0, 40)}...`);
+      }
+    } catch (error) {
+      failed++;
+      console.error(`[LFG] addPeer failed for ${enode.slice(0, 40)}...:`, error);
+    }
+    
+    // Small delay between requests to avoid overwhelming the node
+    if (added + failed < enodes.length) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+  }
+  
+  return { added, failed };
+}
+
+/**
+ * Main LFG check - triggers peer injection if peer count is below threshold
+ */
+export async function lfgCheck(
+  rpcUrl: string, 
+  currentPeers: number
+): Promise<LFGResult> {
+  // Don't trigger if we have enough peers
+  if (currentPeers >= MIN_PEERS) {
+    return { triggered: false, added: 0, failed: 0 };
+  }
+  
+  console.log(`[LFG] Peer count ${currentPeers} < ${MIN_PEERS}, fetching healthy peers...`);
+  
+  const enodes = await fetchHealthyPeers();
+  if (enodes.length === 0) {
+    console.log('[LFG] No healthy peers available from SkyNet');
+    return { triggered: true, added: 0, failed: 0, enodesFetched: 0 };
+  }
+  
+  console.log(`[LFG] Fetched ${enodes.length} healthy peers, adding up to 20...`);
+  
+  // Add up to 20 peers at a time to avoid overwhelming the node
+  const enodesToAdd = enodes.slice(0, 20);
+  const result = await addPeers(rpcUrl, enodesToAdd);
+  
+  console.log(`[LFG] Added ${result.added} peers, ${result.failed} failed`);
+  
+  return { 
+    triggered: true, 
+    ...result,
+    enodesFetched: enodes.length 
+  };
+}
+
+/**
+ * Get LFG configuration info
+ */
+export function getLFGConfig(): { minPeers: number; skyNetUrl: string } {
+  return {
+    minPeers: MIN_PEERS,
+    skyNetUrl: SKYNET_URL,
+  };
+}


### PR DESCRIPTION
Auto-adds healthy peers from SkyNet when peer count drops below MIN_PEERS

## Changes
- Add dashboard/lib/lfg.ts with:
  - fetchHealthyPeers() - fetches from SkyNet healthy endpoint
  - addPeers() - adds peers via admin_addPeer RPC
  - lfgCheck() - main orchestration function
- Integrate LFG into /api/metrics route (triggers when peers < 10)
- Add LFGBadge component showing when peer injection is triggered
- Add /api/lfg/config endpoint

## Environment Variables
- SKYNET_API_URL (default: https://net.xdc.network/api/v1)
- MIN_PEERS (default: 5)

## Dashboard UI
Shows 'LFG Active' badge with +N peers added notification when triggered.