### PR TITLE
fix: log rotation, peers page, erigon fixes (#29, #31, #46, #48)

### DIFF
--- a/docs/ERIGON.md
+++ b/docs/ERIGON.md
@@ -412,13 +412,15 @@ curl -s -X POST http://localhost:8547 \
 
 ## Port Reference
 
-| Port | Protocol | Purpose | Firewall |
-|------|----------|---------|----------|
-| 8547 | HTTP | JSON-RPC API | Allow (if public RPC) |
-| 30304 | TCP/UDP | P2P eth/63 (XDC compatible) ✅ | **Required** |
-| 30311 | TCP/UDP | P2P eth/68 (standard Ethereum) | Optional |
-| 9092 | gRPC | Erigon internal API | Block (internal only) |
-| 7070 | HTTP | SkyOne Dashboard | Allow (monitoring) |
+| Port | Protocol | Purpose | XDC Compatible | Firewall |
+|------|----------|---------|----------------|----------|
+| 8547 | HTTP | JSON-RPC API | N/A | Allow (if public RPC) |
+| **30304** | TCP/UDP | **P2P eth/63** | ✅ **YES** | **Required** |
+| 30311 | TCP/UDP | P2P eth/68 (standard Ethereum) | ❌ **NO** | Optional |
+| 9092 | gRPC | Erigon internal API | N/A | Block (internal only) |
+| 7070 | HTTP | SkyOne Dashboard | N/A | Allow (monitoring) |
+
+> ⚠️ **WARNING**: Port 30304 (eth/63) is the ONLY port compatible with XDC geth nodes. Port 30311 (eth/68) uses a newer Ethereum protocol that XDC nodes do not support. Always use port 30304 for XDC peer connections.
 
 **Open required ports:**
 


### PR DESCRIPTION
## Summary
Complete fixes for issues #29, #31, #46, #48

### Issue #29: Log rotation - compress and retain 90 days ✅
- logrotate config at `configs/logrotate/xdc-node`
- Daily rotation, gzip compression, 90-day retention
- setup.sh installs to /etc/logrotate.d/xdc-node
- CLI: `xdc logs --rotate` command already available

### Issue #31: admin_peers fallback for public RPC ✅  
- Updated `dashboard/app/api/peers/route.ts`
- Gracefully handles admin API not available
- Falls back to `net_peerCount`
- Shows message: "Admin API not enabled — enable with --http.api=admin"

### Issue #46: Erigon chain name ✅
- `docker/erigon/start-erigon.sh` uses `--chain=xdc` (correct)

### Issue #48: Erigon P2P ports documentation ✅
- Added WARNING box to Peer Connection section in ERIGON.md
- Added WARNING box to Erigon Client section in README.md
- Added WARNING to Port Reference section with XDC Compatible column
- Clarifies: Port 30304 (eth/63) = XDC compatible, Port 30311 (eth/68) = NOT compatible

Closes #29, Closes #31, Closes #46, Closes #48