### PR TITLE
feat: bootnodes, auto-update, man pages (#35, #41, #49)

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -2,9 +2,10 @@
 set -euo pipefail
 
 # XDC CLI Installer
-# Installs the 'xdc' command globally
+# Installs the 'xdc' command globally and man pages
 
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+MAN_DIR="${MAN_DIR:-/usr/local/share/man/man1}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
@@ -24,6 +25,25 @@ if [ -d /usr/local/share/zsh/site-functions ]; then
     cp "$SCRIPT_DIR/completions/xdc.zsh" /usr/local/share/zsh/site-functions/_xdc 2>/dev/null || true
 fi
 
+# Install man pages
+if [ -d "$PROJECT_DIR/docs/man" ]; then
+    echo "Installing man pages..."
+    mkdir -p "$MAN_DIR"
+    
+    for manpage in "$PROJECT_DIR/docs/man"/*.1; do
+        if [ -f "$manpage" ]; then
+            cp "$manpage" "$MAN_DIR/"
+            chmod 644 "$MAN_DIR/$(basename "$manpage")"
+            echo "  Installed: $(basename "$manpage")"
+        fi
+    done
+    
+    # Update man database
+    if command -v mandb &> /dev/null; then
+        mandb -q 2>/dev/null || true
+    fi
+fi
+
 echo "✅ XDC CLI installed: $(xdc --version 2>/dev/null || echo 'v1.0.0')"
 echo ""
 echo "Usage:"
@@ -31,7 +51,11 @@ echo "  xdc status        — Show node status"
 echo "  xdc start         — Start XDC node"
 echo "  xdc stop          — Stop XDC node"
 echo "  xdc logs          — View node logs"
-echo "  xdc peers         — Show connected peers"
-echo "  xdc sync          — Show sync progress"
-echo "  xdc health        — Full health check"
+echo "  xdc update        — Update xdc-node-setup"
 echo "  xdc help          — Show all commands"
+echo ""
+echo "Man pages:"
+echo "  man xdc           — Main CLI documentation"
+echo "  man xdc-setup     — Setup command details"
+echo "  man xdc-status    — Status command details"
+echo "  man xdc-security  — Security command details"

--- a/cli/xdc
+++ b/cli/xdc
@@ -1387,24 +1387,49 @@ EOF
 # Command: update
 #==============================================================================
 cmd_update() {
+    local check_only=false
+    local auto_enable=false
+    local auto_disable=false
+    local force=false
+    local target_version=""
+    
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            --check) check_only=true; shift ;;
+            --auto) auto_enable=true; shift ;;
+            --no-auto) auto_disable=true; shift ;;
+            --force) force=true; shift ;;
+            --version) target_version="$2"; shift 2 ;;
             --help|-h)
                 cat << EOF
-$(c BOLD)xdc update$(c NC) — Update node Docker image and restart
+$(c BOLD)xdc update$(c NC) — Update xdc-node-setup and node components
 
 $(c BOLD)USAGE:$(c NC)
-    xdc update
+    xdc update [options]
 
 $(c BOLD)DESCRIPTION:$(c NC)
-    Updates the XDC node Docker image to the latest version:
-    - Backs up current configuration
-    - Pulls the latest Docker image
-    - Restarts the node with the new image
-    - Verifies the node is running and syncing
+    Checks for and applies updates to xdc-node-setup from GitHub releases.
+    Can update the CLI scripts, Docker images, and node configuration.
 
-$(c BOLD)EXAMPLE:$(c NC)
-    xdc update
+$(c BOLD)OPTIONS:$(c NC)
+    --check          Check for available updates without applying
+    --auto           Enable automatic updates via cron
+    --no-auto        Disable automatic updates
+    --force          Apply update without confirmation
+    --version V      Update to specific version (default: latest)
+    --help           Show this help
+
+$(c BOLD)AUTO-UPDATE:$(c NC)
+    When enabled, automatic updates run daily at 3:00 AM.
+    Logs are saved to /var/log/xdc-auto-update.log
+    Backups are created before each update.
+
+$(c BOLD)EXAMPLES:$(c NC)
+    xdc update                    # Check and apply available updates
+    xdc update --check            # Only check for updates
+    xdc update --auto             # Enable auto-updates
+    xdc update --force            # Force update without prompt
+    xdc update --version v1.1.0   # Update to specific version
 
 EOF
                 return 0
@@ -1413,6 +1438,42 @@ EOF
         esac
     done
 
+    # Handle auto-update enable/disable
+    if [[ "$auto_enable" == true ]]; then
+        local auto_update_script="${SCRIPTS_DIR}/auto-update.sh"
+        if [[ -f "$auto_update_script" ]]; then
+            bash "$auto_update_script" setup-cron
+        else
+            error "Auto-update script not found at $auto_update_script"
+            return 1
+        fi
+        return 0
+    fi
+    
+    if [[ "$auto_disable" == true ]]; then
+        local auto_update_script="${SCRIPTS_DIR}/auto-update.sh"
+        if [[ -f "$auto_update_script" ]]; then
+            bash "$auto_update_script" remove-cron
+        else
+            error "Auto-update script not found at $auto_update_script"
+            return 1
+        fi
+        return 0
+    fi
+
+    # Run auto-update check/apply
+    local auto_update_script="${SCRIPTS_DIR}/auto-update.sh"
+    if [[ -f "$auto_update_script" ]]; then
+        local args=()
+        [[ "$check_only" == true ]] && args+=("--check")
+        [[ "$force" == true ]] && args+=("--force")
+        [[ -n "$target_version" ]] && args+=("--version" "$target_version")
+        
+        bash "$auto_update_script" update "${args[@]}"
+        return $?
+    fi
+
+    # Fallback to legacy Docker-based update
     # Determine directories and compose file
     local STATE_DIR="${XDC_STATE_DIR:-${PROJECT_DIR}/${XDC_NETWORK}/.xdc-node}"
     local COMPOSE_FILE="${INSTALL_DIR}/docker/docker-compose.yml"
@@ -3963,7 +4024,41 @@ main() {
         version)    cmd_version "$@" ;;
         client)     cmd_client "$@" ;;
         help|--help|-h)
-            print_help
+            if [[ $# -gt 0 ]]; then
+                # Show help for specific command: xdc help <command>
+                case "$1" in
+                    init)       cmd_init --help ;;
+                    status|info) cmd_status --help ;;
+                    health)     cmd_health --help ;;
+                    security)   cmd_security --help ;;
+                    update)     cmd_update --help ;;
+                    backup)     cmd_backup --help ;;
+                    restore)    cmd_restore --help ;;
+                    logs)       cmd_logs --help ;;
+                    restart)    cmd_restart --help ;;
+                    stop)       cmd_stop --help ;;
+                    start)      cmd_start --help ;;
+                    config)     cmd_config --help ;;
+                    notify)     cmd_notify --help ;;
+                    dashboard)  cmd_dashboard --help ;;
+                    version)    cmd_version --help ;;
+                    client)     cmd_client --help ;;
+                    attach)     cmd_attach --help ;;
+                    masternode) cmd_masternode --help ;;
+                    peers)      cmd_peers --help ;;
+                    snapshot)   cmd_snapshot --help ;;
+                    monitor)    cmd_monitor --help ;;
+                    sync)       cmd_sync --help ;;
+                    consensus)  cmd_consensus --help ;;
+                    governance) cmd_governance --help ;;
+                    rewards)    cmd_rewards --help ;;
+                    cluster)    cmd_cluster --help ;;
+                    stake)      cmd_stake --help ;;
+                    *)          echo "No detailed help for: $1"; echo "Run 'xdc help' for all commands." ;;
+                esac
+            else
+                print_help
+            fi
             ;;
         *)
             error "Unknown command: $command"

--- a/configs/bootnodes.conf
+++ b/configs/bootnodes.conf
@@ -1,0 +1,26 @@
+# XDC Mainnet Bootnodes Configuration
+# This file contains the list of bootnodes used by Erigon-XDC to bootstrap P2P connections.
+# You can add, remove, or modify bootnodes in this file.
+# Lines starting with # are comments and will be ignored.
+#
+# Bootnode format: enode://<node_id>@<ip>:<port>
+#
+# For the full list of XDC bootnodes, see:
+# https://github.com/XinFinOrg/XDC-Node-Setup/blob/main/docker/mainnet/bootnodes.list
+
+# Official XDC Foundation Bootnodes
+enode://e1a69a7d766576e694adc3fc78d801a8a66926cbe8f4fe95b85f3b481444700a5d1b6d440b2715b5bb7cf4824df6a6702740afc8c52b20c72bc8c16f1ccde1f3@149.102.140.32:30303
+enode://874589626a2b4fd7c57202533315885815eba51dbc434db88bbbebcec9b22cf2a01eafad2fd61651306fe85321669a30b3f41112eca230137ded24b86e064ba8@5.189.144.192:30303
+enode://ccdef92053c8b9622180d02a63edffb3e143e7627737ea812b930eacea6c51f0c93a5da3397f59408c3d3d1a9a381f7e0b07440eae47314685b649a03408cfdd@37.60.243.5:30303
+enode://12711126475d7924af98d359e178f71c5d9607de32d2c5b4ab1afff4b0bb16b793b4bbda0a42bf41a309e5349b6106d053ae4ae92aa848b5879e3ef3687c6203@89.117.49.48:30303
+enode://81edfecc3df6994679daf67858ae34c0ae91aac944a84b09171532b45ad0f5d0c896eb8c023df04eaa2db743f5fccdf18cf7e2d12120d37a2c142a3be0a348cd@38.102.87.174:30303
+
+# Community Bootnodes
+enode://053ba696174e7f115e38f0e3963d0035ac20dc18e9a5c5873f9e90fe338d777f726d68d053c987416ec0bd97d4d818c59a8a23bc9ea854069ea2310846e27e7d@162.250.189.221:30303
+enode://b3ce1f8894af033cc2adbcb0836fe18d283af8574c451e385fd362165a6e5eded1b59b640c4d92048283bad9855721345a28ebaf28f66ace00a7134871d1e2a2@38.143.58.166:30303
+enode://938f2e3f409a12573e6da6460b6497c45e2bec393756b989b8874f647911cca39d0ffef8554a45698a8f21a7e870288beb638b3770537a12118e30bd6f9ae806@109.199.104.176:30303
+enode://47350ef305fb1406818a621a0f11144a72d560835a860607b331cef46ac82ea79c7df6bb5e5dba4147a489d9c77bc527f2500ce753fece817bc1a890eb05b886@185.252.233.29:30303
+enode://2ac0472c39e3e0be89bc021689d4c015c455e9f2fe2101bee80b61bba6224c810d200a6d6d17038d5826d522edbcb73a6bc44e492cd5f06a5377aa6eee03335b@144.126.136.27:30303
+
+# Add your own bootnodes below:
+# enode://<your_node_id>@<your_ip>:<your_port>

--- a/docker/erigon/start-erigon.sh
+++ b/docker/erigon/start-erigon.sh
@@ -11,6 +11,22 @@ CONFIG_FILE="/etc/xdc-node/config.toml"
 BOOTNODES_FILE="/bootnodes.list"
 DATADIR="/data"
 
+# XDC Mainnet Bootnodes - used to bootstrap P2P connections
+# These are the same bootnodes used by XDC geth nodes
+# Users can override by creating /etc/xdc-node/bootnodes.conf
+XDC_MAINNET_BOOTNODES=(
+    "enode://e1a69a7d766576e694adc3fc78d801a8a66926cbe8f4fe95b85f3b481444700a5d1b6d440b2715b5bb7cf4824df6a6702740afc8c52b20c72bc8c16f1ccde1f3@149.102.140.32:30303"
+    "enode://874589626a2b4fd7c57202533315885815eba51dbc434db88bbbebcec9b22cf2a01eafad2fd61651306fe85321669a30b3f41112eca230137ded24b86e064ba8@5.189.144.192:30303"
+    "enode://ccdef92053c8b9622180d02a63edffb3e143e7627737ea812b930eacea6c51f0c93a5da3397f59408c3d3d1a9a381f7e0b07440eae47314685b649a03408cfdd@37.60.243.5:30303"
+    "enode://12711126475d7924af98d359e178f71c5d9607de32d2c5b4ab1afff4b0bb16b793b4bbda0a42bf41a309e5349b6106d053ae4ae92aa848b5879e3ef3687c6203@89.117.49.48:30303"
+    "enode://81edfecc3df6994679daf67858ae34c0ae91aac944a84b09171532b45ad0f5d0c896eb8c023df04eaa2db743f5fccdf18cf7e2d12120d37a2c142a3be0a348cd@38.102.87.174:30303"
+    "enode://053ba696174e7f115e38f0e3963d0035ac20dc18e9a5c5873f9e90fe338d777f726d68d053c987416ec0bd97d4d818c59a8a23bc9ea854069ea2310846e27e7d@162.250.189.221:30303"
+    "enode://b3ce1f8894af033cc2adbcb0836fe18d283af8574c451e385fd362165a6e5eded1b59b640c4d92048283bad9855721345a28ebaf28f66ace00a7134871d1e2a2@38.143.58.166:30303"
+    "enode://938f2e3f409a12573e6da6460b6497c45e2bec393756b989b8874f647911cca39d0ffef8554a45698a8f21a7e870288beb638b3770537a12118e30bd6f9ae806@109.199.104.176:30303"
+    "enode://47350ef305fb1406818a621a0f11144a72d560835a860607b331cef46ac82ea79c7df6bb5e5dba4147a489d9c77bc527f2500ce753fece817bc1a890eb05b886@185.252.233.29:30303"
+    "enode://2ac0472c39e3e0be89bc021689d4c015c455e9f2fe2101bee80b61bba6224c810d200a6d6d17038d5826d522edbcb73a6bc44e492cd5f06a5377aa6eee03335b@144.126.136.27:30303"
+)
+
 echo "Starting Erigon-XDC node..."
 echo "Datadir: $DATADIR"
 echo "Config: $CONFIG_FILE"
@@ -81,14 +97,53 @@ echo "Config: sync=$SYNC_MODE log=$LOG_LEVEL rpc=$RPC_ADDR:$RPC_PORT"
 # Parse bootnodes
 # ============================================================
 BOOTNODES=""
-if [ -f "$BOOTNODES_FILE" ]; then
+
+# Function to build bootnodes string from array
+build_bootnodes_from_array() {
+    local arr=("$@")
+    local result=""
+    for node in "${arr[@]}"; do
+        [[ -z "$node" ]] && continue
+        [[ -n "$result" ]] && result="$result,"
+        result="$result$node"
+    done
+    echo "$result"
+}
+
+# 1. Check for user-editable config file
+USER_BOOTNODES_FILE="/etc/xdc-node/bootnodes.conf"
+if [[ -f "$USER_BOOTNODES_FILE" ]]; then
+    echo "Loading bootnodes from user config: $USER_BOOTNODES_FILE"
     while IFS= read -r line; do
-        [[ "$line" =~ ^# ]] && continue
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
         [[ -z "$line" ]] && continue
-        [[ -n "$BOOTNODES" ]] && BOOTNODES="$BOOTNODES,"
-        BOOTNODES="$BOOTNODES$line"
+        if [[ "$line" =~ ^enode:// ]]; then
+            [[ -n "$BOOTNODES" ]] && BOOTNODES="$BOOTNODES,"
+            BOOTNODES="$BOOTNODES$line"
+        fi
+    done < "$USER_BOOTNODES_FILE"
+    echo "Loaded $(echo "$BOOTNODES" | tr ',' '\n' | grep -c 'enode') bootnodes from user config"
+fi
+
+# 2. Check for container-mounted bootnodes.list
+if [[ -z "$BOOTNODES" && -f "$BOOTNODES_FILE" ]]; then
+    echo "Loading bootnodes from $BOOTNODES_FILE"
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "$line" ]] && continue
+        if [[ "$line" =~ ^enode:// ]]; then
+            [[ -n "$BOOTNODES" ]] && BOOTNODES="$BOOTNODES,"
+            BOOTNODES="$BOOTNODES$line"
+        fi
     done < "$BOOTNODES_FILE"
-    echo "Loaded $(echo "$BOOTNODES" | tr ',' '\n' | wc -l) bootnodes"
+    echo "Loaded $(echo "$BOOTNODES" | tr ',' '\n' | grep -c 'enode') bootnodes from $BOOTNODES_FILE"
+fi
+
+# 3. Fallback to built-in XDC mainnet bootnodes
+if [[ -z "$BOOTNODES" ]]; then
+    echo "Using built-in XDC mainnet bootnodes"
+    BOOTNODES=$(build_bootnodes_from_array "${XDC_MAINNET_BOOTNODES[@]}")
+    echo "Loaded ${#XDC_MAINNET_BOOTNODES[@]} built-in bootnodes"
 fi
 
 # ============================================================

--- a/docs/man/xdc-security.1
+++ b/docs/man/xdc-security.1
@@ -1,0 +1,82 @@
+.TH XDC-SECURITY 1 "February 2026" "XDC CLI 1.0.0" "User Commands"
+.SH NAME
+xdc-security \- XDC Node Security Audit
+.SH SYNOPSIS
+.B xdc security
+.RI [ options ]
+.SH DESCRIPTION
+The security command performs a comprehensive audit of the XDC node security
+configuration. By default, it operates in read-only mode and provides
+recommendations without making any changes.
+.SH SECURITY CHECKS
+.SS SSH Configuration
+.TP
+.B Key-Only Authentication
+Verifies PasswordAuthentication is disabled.
+.TP
+.B Non-Standard Port
+Checks if SSH is running on a port other than 22.
+.TP
+.B Root Login Restricted
+Verifies PermitRootLogin is set to 'no'.
+.SS Network Security
+.TP
+.B Firewall Enabled
+Checks if UFW firewall is active.
+.TP
+.B RPC Not Exposed
+Verifies RPC endpoint is not exposed to 0.0.0.0.
+.TP
+.B WebSocket Not Exposed
+Verifies WebSocket endpoint is not exposed externally.
+.SS System Security
+.TP
+.B Fail2ban Active
+Checks if fail2ban intrusion prevention is running.
+.TP
+.B Automatic Updates
+Verifies unattended-upgrades is configured.
+.SH OPTIONS
+.TP
+.B \-\-audit\-only
+Check only, don't apply changes (default behavior).
+.TP
+.B \-\-fix
+Apply recommended security fixes with confirmation.
+.TP
+.B \-\-json
+Output audit results in JSON format.
+.TP
+.B \-\-help, \-h
+Show help message and exit.
+.SH SECURITY SCORE
+The audit provides a score from 0-100:
+.TP
+.B 80-100 (Green)
+Good security posture.
+.TP
+.B 60-79 (Yellow)
+Moderate security. Several recommendations should be addressed.
+.TP
+.B 0-59 (Red)
+Poor security. Immediate attention required.
+.SH EXAMPLES
+.TP
+.B xdc security
+Run security audit in read-only mode.
+.TP
+.B xdc security \-\-fix
+Run audit and apply recommended fixes interactively.
+.TP
+.B xdc security \-\-json
+Output audit results as JSON.
+.SH SEE ALSO
+.BR xdc (1),
+.BR sshd_config (5),
+.BR ufw (8),
+.BR fail2ban (1)
+.SH AUTHOR
+Anil Chinchawale <anil24593@gmail.com>
+.SH SECURITY CONSIDERATIONS
+The \-\-fix option makes system changes. Always have a backup available
+and test SSH access in a new session before closing current session.

--- a/docs/man/xdc-setup.1
+++ b/docs/man/xdc-setup.1
@@ -1,0 +1,57 @@
+.TH XDC-SETUP 1 "February 2026" "XDC CLI 1.0.0" "User Commands"
+.SH NAME
+xdc-setup \- XDC Node Setup and Initialization
+.SH SYNOPSIS
+.B xdc init
+.RI [ options ]
+.SH DESCRIPTION
+The setup command provides an interactive wizard for configuring and deploying
+an XDC Network node. It handles system requirement checks, dependency
+installation, network configuration, and initial node setup.
+.SH OPTIONS
+.TP
+.B \-\-quick
+Run minimal setup with default settings.
+.TP
+.B \-\-help, \-h
+Show help message and exit.
+.SH SETUP PROCESS
+.SS 1. System Requirements Check
+.IP \(bu 4
+Minimum 4 CPU cores (8+ recommended)
+.IP \(bu 4
+Minimum 16GB RAM (32GB+ recommended)
+.IP \(bu 4
+Minimum 500GB free disk space (SSD recommended)
+.SS 2. Client Selection
+.IP \(bu 4
+.B stable
+- XDC Stable - Official Docker image
+.IP \(bu 4
+.B geth-pr5
+- XDC Geth PR5 - Latest with XDPoS v2
+.IP \(bu 4
+.B erigon
+- Erigon-XDC - High-performance implementation
+.SS 3. Network Selection
+.IP \(bu 4
+.B mainnet
+- XDC Main Network (production)
+.IP \(bu 4
+.B testnet
+- XDC Test Network
+.SH EXAMPLES
+.B xdc init
+.RS
+Run full interactive setup wizard.
+.RE
+.PP
+.B xdc init \-\-quick
+.RS
+Run quick setup with defaults.
+.RE
+.SH SEE ALSO
+.BR xdc (1),
+.BR xdc-status (1)
+.SH AUTHOR
+Anil Chinchawale <anil24593@gmail.com>

--- a/docs/man/xdc-status.1
+++ b/docs/man/xdc-status.1
@@ -1,0 +1,64 @@
+.TH XDC-STATUS 1 "February 2026" "XDC CLI 1.0.0" "User Commands"
+.SH NAME
+xdc-status \- XDC Node Status Overview
+.SH SYNOPSIS
+.B xdc status
+.RI [ options ]
+.SH DESCRIPTION
+The status command provides a comprehensive overview of the XDC node state,
+including synchronization progress, peer connections, and system resources.
+.SH OPTIONS
+.TP
+.B \-\-watch, \-w
+Auto-refresh status display every 5 seconds.
+.TP
+.B \-\-interval\ N
+Set custom refresh interval in seconds (default: 5).
+.TP
+.B \-\-json
+Output status in JSON format.
+.TP
+.B \-\-help, \-h
+Show help message and exit.
+.SH OUTPUT COLUMNS
+.TP
+.B Client
+The XDC client type.
+.TP
+.B Block
+Current block height synced.
+.TP
+.B Peers
+Number of connected P2P peers.
+.TP
+.B Sync%
+Synchronization percentage.
+.TP
+.B CPU
+Current CPU usage percentage.
+.TP
+.B RAM
+Current memory usage percentage.
+.TP
+.B Status
+Node status (Online, Syncing, or Offline).
+.SH EXAMPLES
+.B xdc status
+.RS
+Display current node status once.
+.RE
+.PP
+.B xdc status \-\-watch
+.RS
+Continuously monitor status.
+.RE
+.PP
+.B xdc status \-\-json
+.RS
+Output status as JSON.
+.RE
+.SH SEE ALSO
+.BR xdc (1),
+.BR xdc-health (1)
+.SH AUTHOR
+Anil Chinchawale <anil24593@gmail.com>

--- a/docs/man/xdc.1
+++ b/docs/man/xdc.1
@@ -1,0 +1,141 @@
+.TH XDC 1 "February 2026" "XDC CLI 1.0.0" "User Commands"
+.SH NAME
+xdc \- XDC Network Node Management CLI
+.SH SYNOPSIS
+.B xdc
+.RI [ global-options ]\ <command>\ [ options ]\ [ arguments ]
+.SH DESCRIPTION
+.B xdc
+is an enterprise-grade command-line interface for managing XDC Network nodes.
+It provides comprehensive tools for node setup, monitoring, maintenance, and
+participation in the XDC Network consensus.
+.SH GLOBAL OPTIONS
+.TP
+.B \-\-json
+Output results in JSON format for programmatic consumption.
+.TP
+.B \-\-quiet, \-q
+Suppress non-essential output.
+.TP
+.B \-\-verbose, \-v
+Show detailed output and debug information.
+.TP
+.B \-\-no\-color
+Disable colored output.
+.TP
+.B \-\-rpc\ URL
+Override the default RPC endpoint URL.
+.SH COMMANDS
+.SS General Commands
+.TP
+.B init
+Interactive setup wizard for initial node configuration.
+.TP
+.B status
+Show quick node status overview with setup progress.
+.TP
+.B health
+Run comprehensive health checks on the node.
+.TP
+.B security
+Run security audit (advisory only, use \-\-fix to apply).
+.TP
+.B update
+Update node and check for new versions.
+.TP
+.B backup
+Backup chaindata and configuration to archive.
+.TP
+.B restore
+Restore node data from backup archive.
+.TP
+.B logs
+View and tail node logs with filtering options.
+.TP
+.B restart
+Graceful node restart with optional force mode.
+.TP
+.B stop
+Stop all XDC containers and services.
+.TP
+.B start
+Start the XDC node with auto-detection of ports.
+.TP
+.B attach
+Attach to XDC JavaScript console (IPC or RPC).
+.TP
+.B config
+View and edit node configuration.
+.TP
+.B version
+Show CLI, client, and version information.
+.TP
+.B help\ [command]
+Show help message or detailed help for specific command.
+.SS XDC-Specific Commands
+.TP
+.B masternode
+Setup and manage masternode operations.
+.TP
+.B peers
+Optimize peer connections with latency ranking.
+.TP
+.B snapshot
+Manage chain snapshots for faster syncing.
+.TP
+.B consensus
+XDPoS v2 consensus monitoring.
+.TP
+.B governance
+Governance participation.
+.SH EXAMPLES
+.PP
+Initialize a new node:
+.RS
+.B xdc init
+.RE
+.PP
+Check node status:
+.RS
+.B xdc status
+.RE
+.PP
+Check for updates:
+.RS
+.B xdc update \-\-check
+.RE
+.PP
+Enable auto-updates:
+.RS
+.B xdc update \-\-auto
+.RE
+.PP
+Get help for specific command:
+.RS
+.B xdc help start
+.RE
+.SH FILES
+.TP
+.I /opt/xdc-node/config.toml
+Main configuration file.
+.TP
+.I /opt/xdc-node/VERSION
+Current installed version.
+.TP
+.I /etc/xdc-node/bootnodes.conf
+User-editable bootnodes configuration.
+.SH ENVIRONMENT
+.TP
+.B XDC_HOME
+Base directory for XDC node installation (default: /opt/xdc-node).
+.TP
+.B XDC_NETWORK
+Network to use (mainnet, testnet, devnet).
+.SH SEE ALSO
+.BR xdc-setup (1),
+.BR xdc-status (1),
+.BR xdc-security (1)
+.SH AUTHOR
+Anil Chinchawale <anil24593@gmail.com>
+.SH BUGS
+Report bugs at: https://github.com/AnilChinchawale/xdc-node-setup/issues


### PR DESCRIPTION
## Summary
This PR addresses three issues:

### Issue #49: Add bootnodes configuration for Erigon-XDC
- Added XDC mainnet bootnodes list directly to `docker/erigon/start-erigon.sh`
- Created user-editable `configs/bootnodes.conf` template file
- Bootnodes are loaded in priority order: user config > mounted file > built-in list
- Supports custom bootnode configuration without modifying the start script

### Issue #41: Auto-update system
- Enhanced `xdc update` CLI command with new options:
  - `--check` - Check for updates without applying
  - `--auto` - Enable automatic updates via cron (daily at 3 AM)
  - `--no-auto` - Disable automatic updates
  - `--force` - Apply update without confirmation
  - `--version` - Update to a specific version
- Leverages `scripts/auto-update.sh` for version checking against GitHub releases
- Creates backups before each update

### Issue #35: Create man pages for CLI commands
- Created `docs/man/xdc.1` - main CLI documentation covering all commands
- Created `docs/man/xdc-setup.1` - setup/init command details
- Created `docs/man/xdc-status.1` - status command details  
- Created `docs/man/xdc-security.1` - security audit command details
- Updated `cli/install.sh` to install man pages to `/usr/local/share/man/man1/`
- Added `xdc help <command>` syntax for per-command help

## Testing
- [ ] Run `xdc update --check` to verify version checking
- [ ] Run `xdc update --auto` to enable auto-updates
- [ ] Start Erigon node and verify bootnodes are loaded
- [ ] Run `man xdc` to view man pages (after install)
- [ ] Run `xdc help status` to see per-command help

Closes #35, Closes #41, Closes #49