### PR TITLE
feat: Terraform provider & K8s operator CRDs for XDC node management

### DIFF
--- a/docs/K8S-OPERATOR.md
+++ b/docs/K8S-OPERATOR.md
@@ -1,0 +1,135 @@
+# Kubernetes Operator for XDC Network
+
+A Kubernetes operator with Custom Resource Definitions (CRDs) for managing XDC nodes, masternodes, and backups.
+
+## CRD Types
+
+### XDCNode
+
+Defines an XDC node deployment with full lifecycle management.
+
+```yaml
+apiVersion: xdc.network/v1alpha1
+kind: XDCNode
+metadata:
+  name: xdcnode-mainnet
+spec:
+  network: mainnet
+  client: xdcchain
+  rpc:
+    enabled: true
+    port: 8545
+  ws:
+    enabled: true
+    port: 8546
+```
+
+See `k8s/operator/config/samples/xdcnode-mainnet.yaml` for a full example.
+
+### XDCMasternode
+
+Manages masternode registration and staking.
+
+```yaml
+apiVersion: xdc.network/v1alpha1
+kind: XDCMasternode
+metadata:
+  name: masternode-mainnet
+spec:
+  network: mainnet
+  coinbase: "xdc..."
+  stakingAmount: "10000000"
+  keystoreSecret: masternode-keystore
+  nodeRef: xdcnode-mainnet
+```
+
+See `k8s/operator/config/samples/xdcmasternode-mainnet.yaml`.
+
+### XDCBackup
+
+Defines backup policies with scheduling and retention.
+
+```yaml
+apiVersion: xdc.network/v1alpha1
+kind: XDCBackup
+metadata:
+  name: daily-backup
+spec:
+  nodeRef: xdcnode-mainnet
+  schedule: "0 2 * * *"
+  retentionDays: 30
+  destination:
+    type: s3
+    bucket: xdc-backups
+    secretRef: aws-credentials
+```
+
+See `k8s/operator/config/samples/xdcbackup-daily.yaml`.
+
+## Features
+
+- **Automatic node deployment** — declarative XDC node management
+- **Self-healing** — operator restarts failed nodes automatically
+- **Horizontal scaling** — deploy multiple nodes via separate CRs
+- **Configuration management** — all config via CRD spec fields
+- **Masternode lifecycle** — register, monitor, and resign masternodes
+- **Scheduled backups** — cron-based backups with retention policies
+
+## Installation
+
+### Apply CRDs
+
+```bash
+kubectl apply -f k8s/operator/config/crd/
+```
+
+### Deploy Operator
+
+```bash
+kubectl apply -f k8s/operator/config/manager/deployment.yaml
+kubectl apply -f k8s/operator/config/rbac/role.yaml
+```
+
+### Using Helm
+
+```bash
+helm install xdc-node k8s/helm/xdc-node/ -f values.yaml
+```
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────┐
+│              Kubernetes Cluster               │
+│                                               │
+│  ┌─────────────────────────────────────────┐  │
+│  │         XDC Node Operator                │  │
+│  │                                          │  │
+│  │  ┌──────────┐ ┌──────────┐ ┌──────────┐ │  │
+│  │  │ XDCNode  │ │XDCMaster │ │XDCBackup │ │  │
+│  │  │Controller│ │Controller│ │Controller│ │  │
+│  │  └────┬─────┘ └────┬─────┘ └────┬─────┘ │  │
+│  └───────┼─────────────┼────────────┼───────┘  │
+│          ▼             ▼            ▼           │
+│  ┌────────────┐ ┌───────────┐ ┌──────────┐    │
+│  │StatefulSet │ │  Secrets  │ │ CronJobs │    │
+│  │(XDC Nodes) │ │(Keystores)│ │(Backups) │    │
+│  └────────────┘ └───────────┘ └──────────┘    │
+└──────────────────────────────────────────────┘
+```
+
+## Development
+
+```bash
+cd k8s/operator
+
+# Build operator image
+docker build -t xdc-operator:latest .
+
+# Run locally (requires kubeconfig)
+go run ./main.go
+```
+
+## Status
+
+🚧 **Scaffold** — controller reconciliation logic is stubbed. Contributions welcome!

--- a/k8s/operator/api/v1alpha1/xdcbackup_types.go
+++ b/k8s/operator/api/v1alpha1/xdcbackup_types.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2024 XDC Network.
+Licensed under the Apache License, Version 2.0.
+*/
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// XDCBackupSpec defines the desired state of an XDC backup policy.
+type XDCBackupSpec struct {
+	// NodeRef references the XDCNode resource to back up.
+	NodeRef string `json:"nodeRef"`
+
+	// Schedule is a cron expression for backup timing.
+	Schedule string `json:"schedule"`
+
+	// RetentionDays is the number of days to retain backups.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=365
+	// +kubebuilder:default=30
+	RetentionDays int32 `json:"retentionDays,omitempty"`
+
+	// Destination configures where backups are stored.
+	Destination BackupDestination `json:"destination"`
+
+	// Compression enables gzip compression of backups.
+	// +kubebuilder:default=true
+	Compression bool `json:"compression,omitempty"`
+
+	// Suspend pauses scheduled backups when true.
+	// +optional
+	Suspend bool `json:"suspend,omitempty"`
+}
+
+// BackupDestination defines the backup storage target.
+type BackupDestination struct {
+	// Type is the destination type.
+	// +kubebuilder:validation:Enum=s3;gcs;pvc
+	Type string `json:"type"`
+
+	// Bucket is the S3/GCS bucket name.
+	// +optional
+	Bucket string `json:"bucket,omitempty"`
+
+	// Path is the prefix/path within the bucket or PVC.
+	// +optional
+	Path string `json:"path,omitempty"`
+
+	// SecretRef references credentials for the backup destination.
+	// +optional
+	SecretRef string `json:"secretRef,omitempty"`
+
+	// PVCName is the PersistentVolumeClaim name (for pvc type).
+	// +optional
+	PVCName string `json:"pvcName,omitempty"`
+}
+
+// XDCBackupStatus defines the observed state of XDCBackup.
+type XDCBackupStatus struct {
+	// LastBackupTime is the timestamp of the last successful backup.
+	// +optional
+	LastBackupTime *metav1.Time `json:"lastBackupTime,omitempty"`
+
+	// LastBackupSize is the size of the last backup in bytes.
+	LastBackupSize int64 `json:"lastBackupSize,omitempty"`
+
+	// BackupCount is the total number of stored backups.
+	BackupCount int32 `json:"backupCount,omitempty"`
+
+	// Phase is the current backup status.
+	// +kubebuilder:validation:Enum=Active;Running;Failed;Suspended
+	Phase string `json:"phase,omitempty"`
+
+	// Conditions represent the latest available observations.
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.spec.nodeRef`
+// +kubebuilder:printcolumn:name="Schedule",type=string,JSONPath=`.spec.schedule`
+// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+
+// XDCBackup is the Schema for the xdcbackups API.
+type XDCBackup struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   XDCBackupSpec   `json:"spec,omitempty"`
+	Status XDCBackupStatus `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// XDCBackupList contains a list of XDCBackup.
+type XDCBackupList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []XDCBackup `json:"items"`
+}

--- a/k8s/operator/api/v1alpha1/xdcmasternode_types.go
+++ b/k8s/operator/api/v1alpha1/xdcmasternode_types.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2024 XDC Network.
+Licensed under the Apache License, Version 2.0.
+*/
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// XDCMasternodeSpec defines the desired state of an XDC masternode.
+type XDCMasternodeSpec struct {
+	// Network is the XDC network (mainnet or testnet).
+	// +kubebuilder:validation:Enum=mainnet;testnet
+	Network string `json:"network"`
+
+	// Coinbase is the masternode's coinbase address.
+	Coinbase string `json:"coinbase"`
+
+	// StakingAmount is the amount of XDC staked (default "10000000").
+	// +optional
+	StakingAmount string `json:"stakingAmount,omitempty"`
+
+	// KeystoreSecret references a Kubernetes secret containing the keystore.
+	KeystoreSecret string `json:"keystoreSecret"`
+
+	// NodeRef references the XDCNode resource this masternode is associated with.
+	// +optional
+	NodeRef string `json:"nodeRef,omitempty"`
+
+	// Image is the container image for the masternode.
+	// +optional
+	Image string `json:"image,omitempty"`
+
+	// Resources defines CPU/memory requests and limits.
+	// +optional
+	Resources *ResourceRequirements `json:"resources,omitempty"`
+}
+
+// ResourceRequirements defines compute resources.
+type ResourceRequirements struct {
+	CPURequest    string `json:"cpuRequest,omitempty"`
+	CPULimit      string `json:"cpuLimit,omitempty"`
+	MemoryRequest string `json:"memoryRequest,omitempty"`
+	MemoryLimit   string `json:"memoryLimit,omitempty"`
+}
+
+// XDCMasternodeStatus defines the observed state of XDCMasternode.
+type XDCMasternodeStatus struct {
+	// Phase is the current lifecycle phase.
+	// +kubebuilder:validation:Enum=Pending;Registering;Active;Resigned;Failed
+	Phase string `json:"phase,omitempty"`
+
+	// Epoch is the current epoch number.
+	Epoch int64 `json:"epoch,omitempty"`
+
+	// Conditions represent the latest available observations.
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Network",type=string,JSONPath=`.spec.network`
+// +kubebuilder:printcolumn:name="Coinbase",type=string,JSONPath=`.spec.coinbase`
+// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+
+// XDCMasternode is the Schema for the xdcmasternodes API.
+type XDCMasternode struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   XDCMasternodeSpec   `json:"spec,omitempty"`
+	Status XDCMasternodeStatus `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// XDCMasternodeList contains a list of XDCMasternode.
+type XDCMasternodeList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []XDCMasternode `json:"items"`
+}

--- a/k8s/operator/config/crd/xdcbackup.yaml
+++ b/k8s/operator/config/crd/xdcbackup.yaml
@@ -1,0 +1,119 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: xdcbackups.xdc.network
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+spec:
+  group: xdc.network
+  names:
+    kind: XDCBackup
+    listKind: XDCBackupList
+    plural: xdcbackups
+    singular: xdcbackup
+    shortNames:
+      - xdcbk
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Node
+          type: string
+          jsonPath: .spec.nodeRef
+        - name: Schedule
+          type: string
+          jsonPath: .spec.schedule
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Last Backup
+          type: date
+          jsonPath: .status.lastBackupTime
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: XDCBackup defines a backup policy for XDC node data.
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - nodeRef
+                - schedule
+                - destination
+              properties:
+                nodeRef:
+                  type: string
+                  description: Reference to the XDCNode to back up.
+                schedule:
+                  type: string
+                  description: Cron expression for backup schedule.
+                retentionDays:
+                  type: integer
+                  minimum: 1
+                  maximum: 365
+                  default: 30
+                compression:
+                  type: boolean
+                  default: true
+                suspend:
+                  type: boolean
+                  default: false
+                destination:
+                  type: object
+                  required:
+                    - type
+                  properties:
+                    type:
+                      type: string
+                      enum: [s3, gcs, pvc]
+                    bucket:
+                      type: string
+                    path:
+                      type: string
+                    secretRef:
+                      type: string
+                    pvcName:
+                      type: string
+            status:
+              type: object
+              properties:
+                lastBackupTime:
+                  type: string
+                  format: date-time
+                lastBackupSize:
+                  type: integer
+                  format: int64
+                backupCount:
+                  type: integer
+                phase:
+                  type: string
+                  enum: [Active, Running, Failed, Suspended]
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      reason:
+                        type: string
+                      message:
+                        type: string

--- a/k8s/operator/config/crd/xdcmasternode.yaml
+++ b/k8s/operator/config/crd/xdcmasternode.yaml
@@ -1,0 +1,106 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: xdcmasternodes.xdc.network
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+spec:
+  group: xdc.network
+  names:
+    kind: XDCMasternode
+    listKind: XDCMasternodeList
+    plural: xdcmasternodes
+    singular: xdcmasternode
+    shortNames:
+      - xdcmn
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Network
+          type: string
+          jsonPath: .spec.network
+        - name: Coinbase
+          type: string
+          jsonPath: .spec.coinbase
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: XDCMasternode is the Schema for managing XDC masternodes.
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - network
+                - coinbase
+                - keystoreSecret
+              properties:
+                network:
+                  type: string
+                  enum: [mainnet, testnet]
+                coinbase:
+                  type: string
+                  description: Masternode coinbase address.
+                stakingAmount:
+                  type: string
+                  default: "10000000"
+                keystoreSecret:
+                  type: string
+                  description: Name of the Kubernetes Secret containing the keystore.
+                nodeRef:
+                  type: string
+                  description: Reference to the associated XDCNode resource.
+                image:
+                  type: string
+                resources:
+                  type: object
+                  properties:
+                    cpuRequest:
+                      type: string
+                    cpuLimit:
+                      type: string
+                    memoryRequest:
+                      type: string
+                    memoryLimit:
+                      type: string
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum: [Pending, Registering, Active, Resigned, Failed]
+                epoch:
+                  type: integer
+                  format: int64
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      reason:
+                        type: string
+                      message:
+                        type: string

--- a/k8s/operator/config/samples/xdcbackup-daily.yaml
+++ b/k8s/operator/config/samples/xdcbackup-daily.yaml
@@ -1,0 +1,30 @@
+apiVersion: xdc.network/v1alpha1
+kind: XDCBackup
+metadata:
+  name: daily-backup
+  namespace: xdc-network
+spec:
+  nodeRef: xdcnode-mainnet
+  schedule: "0 2 * * *"
+  retentionDays: 30
+  compression: true
+  destination:
+    type: s3
+    bucket: xdc-node-backups
+    path: mainnet/daily
+    secretRef: aws-backup-credentials
+---
+apiVersion: xdc.network/v1alpha1
+kind: XDCBackup
+metadata:
+  name: weekly-backup-pvc
+  namespace: xdc-network
+spec:
+  nodeRef: xdcnode-mainnet
+  schedule: "0 3 * * 0"
+  retentionDays: 90
+  compression: true
+  destination:
+    type: pvc
+    pvcName: xdc-backup-volume
+    path: /backups/weekly

--- a/k8s/operator/config/samples/xdcmasternode-mainnet.yaml
+++ b/k8s/operator/config/samples/xdcmasternode-mainnet.yaml
@@ -1,0 +1,17 @@
+apiVersion: xdc.network/v1alpha1
+kind: XDCMasternode
+metadata:
+  name: masternode-mainnet
+  namespace: xdc-network
+spec:
+  network: mainnet
+  coinbase: "xdc0000000000000000000000000000000000000001"
+  stakingAmount: "10000000"
+  keystoreSecret: masternode-keystore
+  nodeRef: xdcnode-mainnet
+  image: xinfinorg/xdcchain:latest
+  resources:
+    cpuRequest: "2"
+    cpuLimit: "4"
+    memoryRequest: "8Gi"
+    memoryLimit: "16Gi"

--- a/k8s/operator/controllers/xdcbackup_controller.go
+++ b/k8s/operator/controllers/xdcbackup_controller.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2024 XDC Network.
+Licensed under the Apache License, Version 2.0.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// XDCBackupReconciler reconciles XDCBackup objects.
+type XDCBackupReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=xdc.network,resources=xdcbackups,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=xdc.network,resources=xdcbackups/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=batch,resources=cronjobs;jobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch
+
+// Reconcile handles XDCBackup create/update/delete events.
+func (r *XDCBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Reconciling XDCBackup", "name", req.NamespacedName)
+
+	// TODO: Implement backup reconciliation logic:
+	// 1. Fetch the XDCBackup resource
+	// 2. Create/update a CronJob for the backup schedule
+	// 3. Manage backup retention (delete old backups)
+	// 4. Update status with last backup time and count
+	// 5. Handle suspend/resume
+
+	_ = errors.IsNotFound(nil)
+	_ = fmt.Sprintf("")
+	_ = time.Now()
+
+	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *XDCBackupReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		// TODO: For(&xdcv1alpha1.XDCBackup{}).
+		Complete(r)
+}

--- a/k8s/operator/controllers/xdcmasternode_controller.go
+++ b/k8s/operator/controllers/xdcmasternode_controller.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 XDC Network.
+Licensed under the Apache License, Version 2.0.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// XDCMasternodeReconciler reconciles XDCMasternode objects.
+type XDCMasternodeReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=xdc.network,resources=xdcmasternodes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=xdc.network,resources=xdcmasternodes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+
+// Reconcile handles XDCMasternode create/update/delete events.
+func (r *XDCMasternodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Reconciling XDCMasternode", "name", req.NamespacedName)
+
+	// TODO: Implement masternode reconciliation logic:
+	// 1. Fetch the XDCMasternode resource
+	// 2. Ensure associated XDCNode is running
+	// 3. Load keystore from referenced Secret
+	// 4. Register/manage masternode on-chain
+	// 5. Update status with current epoch and phase
+
+	_ = errors.IsNotFound(nil) // placeholder to use import
+	_ = fmt.Sprintf("")
+	_ = time.Now()
+
+	return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *XDCMasternodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		// TODO: For(&xdcv1alpha1.XDCMasternode{}).
+		Complete(r)
+}

--- a/terraform/provider/Makefile
+++ b/terraform/provider/Makefile
@@ -1,0 +1,23 @@
+HOSTNAME=registry.terraform.io
+NAMESPACE=AnilChinchawale
+NAME=xdc
+BINARY=terraform-provider-${NAME}
+VERSION=0.1.0
+OS_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)
+
+default: build
+
+build:
+	go build -o ${BINARY}
+
+install: build
+	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}/
+
+test:
+	go test -v ./...
+
+fmt:
+	gofmt -w .
+
+.PHONY: build install test fmt

--- a/terraform/provider/README.md
+++ b/terraform/provider/README.md
@@ -1,0 +1,99 @@
+# Terraform Provider for XDC Network
+
+Custom Terraform provider for managing XDC node infrastructure.
+
+## Resources
+
+| Resource | Description |
+|----------|-------------|
+| `xdc_node` | Manage XDC node instances |
+| `xdc_masternode` | Manage masternode configuration and staking |
+| `xdc_backup` | Manage backup schedules |
+| `xdc_monitor` | Configure monitoring and alerts |
+
+## Data Sources
+
+| Data Source | Description |
+|-------------|-------------|
+| `xdc_network` | Get network information (block height, epoch, gas price) |
+| `xdc_validators` | Get current validator list |
+
+## Quick Start
+
+```hcl
+terraform {
+  required_providers {
+    xdc = {
+      source  = "AnilChinchawale/xdc"
+      version = "~> 0.1"
+    }
+  }
+}
+
+provider "xdc" {
+  endpoint    = "https://rpc.xinfin.network"
+  private_key = var.xdc_private_key
+}
+
+# Deploy an XDC node
+resource "xdc_node" "mainnet" {
+  name    = "my-xdc-node"
+  network = "mainnet"
+  client  = "xdcchain"
+
+  rpc_enabled = true
+  rpc_port    = 8545
+  ws_enabled  = true
+  ws_port     = 8546
+}
+
+# Configure masternode
+resource "xdc_masternode" "primary" {
+  name           = "my-masternode"
+  network        = "mainnet"
+  coinbase       = "xdc..."
+  staking_amount = "10000000"
+  keystore_path  = var.keystore_path
+}
+
+# Set up backups
+resource "xdc_backup" "daily" {
+  node_id          = xdc_node.mainnet.id
+  schedule         = "0 2 * * *"
+  retention_days   = 30
+  destination      = "s3"
+  destination_path = "s3://my-bucket/xdc-backups"
+}
+
+# Configure monitoring
+resource "xdc_monitor" "alerts" {
+  node_id         = xdc_node.mainnet.id
+  metrics_enabled = true
+  metrics_port    = 9090
+  alert_email     = "ops@example.com"
+
+  alert_rules {
+    name      = "high-peer-drop"
+    condition = "peer_count < 5"
+    threshold = 5
+    severity  = "critical"
+  }
+}
+
+# Read network info
+data "xdc_network" "info" {}
+
+data "xdc_validators" "current" {}
+```
+
+## Building
+
+```bash
+make build    # Build the provider binary
+make install  # Install to local Terraform plugin directory
+make test     # Run tests
+```
+
+## Status
+
+🚧 **Scaffold** — resource CRUD operations are stubbed. Contributions welcome!

--- a/terraform/provider/data_source_xdc_network.go
+++ b/terraform/provider/data_source_xdc_network.go
@@ -1,0 +1,48 @@
+package main
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+func dataSourceXDCNetwork() *schema.Resource {
+	return &schema.Resource{
+		Description: "Retrieves information about the XDC network.",
+		Read:        dataSourceXDCNetworkRead,
+		Schema: map[string]*schema.Schema{
+			"network_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Network chain ID (50 = mainnet, 51 = testnet).",
+			},
+			"latest_block": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Latest block number.",
+			},
+			"current_epoch": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Current epoch number.",
+			},
+			"gas_price": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Current gas price in wei.",
+			},
+			"peer_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Number of connected peers.",
+			},
+			"syncing": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the node is syncing.",
+			},
+		},
+	}
+}
+
+func dataSourceXDCNetworkRead(d *schema.ResourceData, meta interface{}) error {
+	// TODO: Query network info via RPC
+	d.SetId("xdc-network")
+	return nil
+}

--- a/terraform/provider/data_source_xdc_validators.go
+++ b/terraform/provider/data_source_xdc_validators.go
@@ -1,0 +1,53 @@
+package main
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+func dataSourceXDCValidators() *schema.Resource {
+	return &schema.Resource{
+		Description: "Retrieves the current validator set from the XDC network.",
+		Read:        dataSourceXDCValidatorsRead,
+		Schema: map[string]*schema.Schema{
+			"epoch": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "Epoch to query (defaults to current).",
+			},
+			"validators": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"address": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Validator address.",
+						},
+						"capacity": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Total staked capacity.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Validator status (active, standby, penalty).",
+						},
+					},
+				},
+				Description: "List of validators.",
+			},
+			"total_validators": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Total number of validators.",
+			},
+		},
+	}
+}
+
+func dataSourceXDCValidatorsRead(d *schema.ResourceData, meta interface{}) error {
+	// TODO: Query validator list from XDC master contract
+	d.SetId("xdc-validators")
+	return nil
+}

--- a/terraform/provider/go.mod
+++ b/terraform/provider/go.mod
@@ -1,0 +1,7 @@
+module github.com/AnilChinchawale/terraform-provider-xdc
+
+go 1.21
+
+require (
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
+)

--- a/terraform/provider/main.go
+++ b/terraform/provider/main.go
@@ -1,0 +1,75 @@
+// Copyright 2024 XDC Network. Apache-2.0 License.
+// terraform-provider-xdc – custom Terraform provider for XDC node management.
+
+package main
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: Provider,
+	})
+}
+
+// Provider returns the XDC Terraform provider schema.
+func Provider() *schema.Provider {
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"endpoint": {
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("XDC_ENDPOINT", "https://rpc.xinfin.network"),
+				Description: "XDC network RPC endpoint.",
+			},
+			"private_key": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				DefaultFunc: schema.EnvDefaultFunc("XDC_PRIVATE_KEY", nil),
+				Description: "Private key for signing transactions.",
+			},
+		},
+		ResourcesMap: map[string]*schema.Resource{
+			"xdc_node":       resourceXDCNode(),
+			"xdc_masternode": resourceXDCMasternode(),
+			"xdc_backup":     resourceXDCBackup(),
+			"xdc_monitor":    resourceXDCMonitor(),
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"xdc_network":    dataSourceXDCNetwork(),
+			"xdc_validators": dataSourceXDCValidators(),
+		},
+		ConfigureFunc: providerConfigure,
+	}
+}
+
+func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	config := &Config{
+		Endpoint:   d.Get("endpoint").(string),
+		PrivateKey: d.Get("private_key").(string),
+	}
+	return config.Client()
+}
+
+// Config holds provider configuration.
+type Config struct {
+	Endpoint   string
+	PrivateKey string
+}
+
+// Client returns an API client for the XDC network.
+func (c *Config) Client() (*APIClient, error) {
+	return &APIClient{
+		Endpoint:   c.Endpoint,
+		PrivateKey: c.PrivateKey,
+	}, nil
+}
+
+// APIClient is the XDC API client used by resources and data sources.
+type APIClient struct {
+	Endpoint   string
+	PrivateKey string
+}

--- a/terraform/provider/resource_xdc_backup.go
+++ b/terraform/provider/resource_xdc_backup.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceXDCBackup() *schema.Resource {
+	return &schema.Resource{
+		Description: "Manages backup schedules for XDC node data.",
+		Create:      resourceXDCBackupCreate,
+		Read:        resourceXDCBackupRead,
+		Update:      resourceXDCBackupUpdate,
+		Delete:      resourceXDCBackupDelete,
+		Schema: map[string]*schema.Schema{
+			"node_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "ID of the XDC node to back up.",
+			},
+			"schedule": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Cron schedule expression (e.g. '0 2 * * *').",
+			},
+			"retention_days": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      30,
+				ValidateFunc: validation.IntBetween(1, 365),
+				Description:  "Number of days to retain backups.",
+			},
+			"destination": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validation.StringInSlice([]string{"s3", "gcs", "local"}, false),
+				Description:      "Backup destination type.",
+			},
+			"destination_path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Destination path or bucket URI.",
+			},
+			"compression": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Enable gzip compression.",
+			},
+			// Computed
+			"last_backup": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Timestamp of the last successful backup.",
+			},
+		},
+	}
+}
+
+func resourceXDCBackupCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(d.Get("node_id").(string) + "-backup")
+	return resourceXDCBackupRead(d, meta)
+}
+
+func resourceXDCBackupRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceXDCBackupUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceXDCBackupRead(d, meta)
+}
+
+func resourceXDCBackupDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}

--- a/terraform/provider/resource_xdc_masternode.go
+++ b/terraform/provider/resource_xdc_masternode.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceXDCMasternode() *schema.Resource {
+	return &schema.Resource{
+		Description: "Manages an XDC masternode with staking configuration.",
+		Create:      resourceXDCMasternodeCreate,
+		Read:        resourceXDCMasternodeRead,
+		Update:      resourceXDCMasternodeUpdate,
+		Delete:      resourceXDCMasternodeDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Masternode name.",
+			},
+			"network": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateFunc:     validation.StringInSlice([]string{"mainnet", "testnet"}, false),
+				Description:      "Network (mainnet, testnet).",
+			},
+			"coinbase": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Coinbase address for the masternode.",
+			},
+			"staking_amount": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "10000000",
+				Description: "XDC staking amount (default 10M for mainnet).",
+			},
+			"keystore_path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: "Path to the keystore file.",
+			},
+			// Computed
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Current masternode status.",
+			},
+			"epoch": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Current epoch number.",
+			},
+		},
+	}
+}
+
+func resourceXDCMasternodeCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(d.Get("coinbase").(string))
+	return resourceXDCMasternodeRead(d, meta)
+}
+
+func resourceXDCMasternodeRead(d *schema.ResourceData, meta interface{}) error {
+	// TODO: Query masternode status from chain
+	return nil
+}
+
+func resourceXDCMasternodeUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceXDCMasternodeRead(d, meta)
+}
+
+func resourceXDCMasternodeDelete(d *schema.ResourceData, meta interface{}) error {
+	// TODO: Resign masternode
+	d.SetId("")
+	return nil
+}

--- a/terraform/provider/resource_xdc_monitor.go
+++ b/terraform/provider/resource_xdc_monitor.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceXDCMonitor() *schema.Resource {
+	return &schema.Resource{
+		Description: "Configures monitoring for an XDC node.",
+		Create:      resourceXDCMonitorCreate,
+		Read:        resourceXDCMonitorRead,
+		Update:      resourceXDCMonitorUpdate,
+		Delete:      resourceXDCMonitorDelete,
+		Schema: map[string]*schema.Schema{
+			"node_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "ID of the XDC node to monitor.",
+			},
+			"metrics_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Enable Prometheus metrics export.",
+			},
+			"metrics_port": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      9090,
+				ValidateFunc: validation.IsPortNumber,
+				Description:  "Prometheus metrics port.",
+			},
+			"alert_email": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Email address for alerts.",
+			},
+			"alert_webhook": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Webhook URL for alerts (Slack, Discord, etc.).",
+			},
+			"health_check_interval": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      60,
+				ValidateFunc: validation.IntBetween(10, 3600),
+				Description:  "Health check interval in seconds.",
+			},
+			"alert_rules": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {Type: schema.TypeString, Required: true},
+						"condition": {Type: schema.TypeString, Required: true},
+						"threshold": {Type: schema.TypeFloat, Required: true},
+						"severity": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "warning",
+							ValidateFunc: validation.StringInSlice([]string{"info", "warning", "critical"}, false),
+						},
+					},
+				},
+				Description: "Custom alert rules.",
+			},
+		},
+	}
+}
+
+func resourceXDCMonitorCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(d.Get("node_id").(string) + "-monitor")
+	return resourceXDCMonitorRead(d, meta)
+}
+
+func resourceXDCMonitorRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceXDCMonitorUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceXDCMonitorRead(d, meta)
+}
+
+func resourceXDCMonitorDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}

--- a/terraform/provider/resource_xdc_node.go
+++ b/terraform/provider/resource_xdc_node.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceXDCNode() *schema.Resource {
+	return &schema.Resource{
+		Description: "Manages an XDC node instance.",
+		Create:      resourceXDCNodeCreate,
+		Read:        resourceXDCNodeRead,
+		Update:      resourceXDCNodeUpdate,
+		Delete:      resourceXDCNodeDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the XDC node.",
+			},
+			"network": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateFunc:     validation.StringInSlice([]string{"mainnet", "testnet", "devnet"}, false),
+				Description:      "Network type (mainnet, testnet, devnet).",
+			},
+			"client": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "xdcchain",
+				ValidateFunc:     validation.StringInSlice([]string{"xdcchain", "xinfinorg"}, false),
+				Description:      "Client implementation to use.",
+			},
+			"data_dir": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "/data/xdc",
+				Description: "Data directory for blockchain data.",
+			},
+			"rpc_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Enable RPC interface.",
+			},
+			"rpc_port": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      8545,
+				ValidateFunc: validation.IsPortNumber,
+				Description:  "RPC port.",
+			},
+			"ws_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Enable WebSocket interface.",
+			},
+			"ws_port": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      8546,
+				ValidateFunc: validation.IsPortNumber,
+				Description:  "WebSocket port.",
+			},
+			"p2p_port": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      30303,
+				ValidateFunc: validation.IsPortNumber,
+				Description:  "P2P discovery port.",
+			},
+			"extra_flags": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Additional command-line flags.",
+			},
+			// Computed
+			"enode": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Enode URL for peer connections.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Current node status.",
+			},
+		},
+	}
+}
+
+func resourceXDCNodeCreate(d *schema.ResourceData, meta interface{}) error {
+	// TODO: Implement node creation via API client
+	d.SetId(d.Get("name").(string))
+	return resourceXDCNodeRead(d, meta)
+}
+
+func resourceXDCNodeRead(d *schema.ResourceData, meta interface{}) error {
+	// TODO: Implement node state read
+	return nil
+}
+
+func resourceXDCNodeUpdate(d *schema.ResourceData, meta interface{}) error {
+	// TODO: Implement node update
+	return resourceXDCNodeRead(d, meta)
+}
+
+func resourceXDCNodeDelete(d *schema.ResourceData, meta interface{}) error {
+	// TODO: Implement node deletion
+	d.SetId("")
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds scaffolding for a custom Terraform provider and extends the Kubernetes operator with new CRDs.

### Terraform Provider (Closes #39)
- Custom Go provider under `terraform/provider/`
- **Resources:** `xdc_node`, `xdc_masternode`, `xdc_backup`, `xdc_monitor`
- **Data sources:** `xdc_network`, `xdc_validators`
- Makefile, go.mod, README with usage examples

### Kubernetes Operator CRDs (Closes #40)
- **XDCMasternode** CRD — manage masternode registration/staking
- **XDCBackup** CRD — scheduled backups with retention policies
- Controller scaffolds for both new CRDs
- Sample manifests for mainnet masternode and daily/weekly backups
- `docs/K8S-OPERATOR.md` with architecture diagram and usage

### Status
🚧 Scaffold — CRUD operations and controller reconciliation are stubbed for community contribution.